### PR TITLE
Added `NODE_HEAPDUMP_FOLDER` handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Load the add-on in your application:
 
 The module exports a single `writeSnapshot([filename], [callback])` function
 that writes out a snapshot.  `filename` defaults to
-`heapdump-<sec>.<usec>.heapsnapshot` when omitted.
+`heapdump-<sec>.<usec>.heapsnapshot` when omitted. You can specify `NODE_HEAPDUMP_FOLDER` env variables, 
+in case if you want to save snapshots in different folder than applications working directory.
 
     heapdump.writeSnapshot('/var/local/' + Date.now() + '.heapsnapshot');
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Load the add-on in your application:
 
 The module exports a single `writeSnapshot([filename], [callback])` function
 that writes out a snapshot.  `filename` defaults to
-`heapdump-<sec>.<usec>.heapsnapshot` when omitted. You can specify `NODE_HEAPDUMP_FOLDER` env variables, 
-in case if you want to save snapshots in different folder than applications working directory.
+`heapdump-<sec>.<usec>.heapsnapshot` when omitted. You can specify `NODE_HEAPDUMP_FOLDER` env variables 
+(`NODE_HEAPDUMP_FOLDER="/var/heapdumps/"`, trailing slash _must_ be presenet), in case if you want to 
+save snapshots in different folder than applications working directory.
 
     heapdump.writeSnapshot('/var/local/' + Date.now() + '.heapsnapshot');
 

--- a/src/heapdump.cc
+++ b/src/heapdump.cc
@@ -112,7 +112,18 @@ inline void RandomSnapshotFilename(char* buffer, size_t size) {
   const uint64_t now = uv_hrtime();
   const unsigned long sec = static_cast<unsigned long>(now / 1000000);
   const unsigned long usec = static_cast<unsigned long>(now % 1000000);
-  snprintf(buffer, size, "heapdump-%lu.%lu.heapsnapshot", sec, usec);
+
+  const char* env_heapdump_folder = getenv("NODE_HEAPDUMP_FOLDER");
+  std::string heapdump_folder_name = "";
+
+  if ( NULL != env_heapdump_folder ) {
+    heapdump_folder_name = env_heapdump_folder;
+  }
+
+  size += heapdump_folder_name.size();
+
+  snprintf(buffer, size, "%sheapdump-%lu.%lu.heapsnapshot", heapdump_folder_name.c_str(), sec, usec);
+
 }
 
 NAN_METHOD(Configure) {

--- a/test/test-sigusr2.js
+++ b/test/test-sigusr2.js
@@ -31,7 +31,12 @@ function testSigUsr2(test){
     console.log('Listening on http://127.0.0.1:8000/');
     console.log('now sending SIGUSR2 to %d', process.pid);
 
-    var heapSnapshotFile = 'heapdump-*.heapsnapshot';
+    var heapdumpFolder = "heapdump/";
+
+    shelljs.mkdir(heapdumpFolder);
+    process.env.NODE_HEAPDUMP_FOLDER = heapdumpFolder;
+
+    var heapSnapshotFile = heapdumpFolder + 'heapdump-*.heapsnapshot';
     shelljs.rm('-f', heapSnapshotFile);
 
     var killCmd = shelljs.which('kill');
@@ -42,8 +47,13 @@ function testSigUsr2(test){
       var files = shelljs.ls(heapSnapshotFile);
       test.equals(files.length, 1, 'Heap file should be present');
       server.close();
+
+      shelljs.rm("-f", heapSnapshotFile);
+      shelljs.rm("-r", heapdumpFolder);
+
       test.end();
     }
+
 
     setTimeout(waitForHeapdump, 500);
   });


### PR DESCRIPTION
 * you can specify in which folder heapdump will be saved - env variable `NODE_HEAPDUMP_FOLDER`
 * updated sigusr2 test to use NODE_HEAPDUMP_FOLDER variable